### PR TITLE
Remove instructions specific to JavaFX

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,19 +127,6 @@ jar {
     }
 }
 
-publishing {
-    publications {
-        main(MavenPublication) {
-            pom.withXml {
-                asNode().dependencies.'*'.findAll {
-                    it.groupId.text() == 'org.openjfx'
-                }.each {
-                    it.remove(it.classifier)
-                }
-            }
-        }
-    }
-}
 
 // start the app from gradle
 task Demo(type: JavaExec) {


### PR DESCRIPTION
The project does not consume JavaFX as dependency thus the snippet related to pom configuration can be removed.